### PR TITLE
Add components to models21 ontology

### DIFF
--- a/owl/models21_test.owl
+++ b/owl/models21_test.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://ros/mros#"
-     xml:base="http://ros/mros"
+<rdf:RDF xmlns="http://models21#"
+     xml:base="http://models21"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -16,6 +16,69 @@
         <owl:imports rdf:resource="http://ros/navigation_domain"/>
     </owl:Ontology>
     
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://metacontrol.org/tomasys#comp_status -->
+
+    <owl:AnnotationProperty rdf:about="http://metacontrol.org/tomasys#comp_status">
+        <rdfs:domain rdf:resource="http://metacontrol.org/tomasys#Component"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://metacontrol.org/tomasys#cspec_availability -->
+
+    <rdf:Description rdf:about="http://metacontrol.org/tomasys#cspec_availability">
+        <rdfs:domain rdf:resource="http://metacontrol.org/tomasys#Component"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://metacontrol.org/tomasys#hasNFR -->
+
+    <owl:AnnotationProperty rdf:about="http://metacontrol.org/tomasys#hasNFR"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://metacontrol.org/tomasys#hasNFR -->
+
+    <rdf:Description rdf:about="http://metacontrol.org/tomasys#hasNFR">
+        <rdfs:domain rdf:resource="http://metacontrol.org/tomasys#Objective"/>
+    </rdf:Description>
+    
+
+
+    <!-- http://ros/mros#requiredBy -->
+
+    <owl:ObjectProperty rdf:about="http://ros/mros#requiredBy">
+        <rdfs:domain rdf:resource="http://metacontrol.org/tomasys#Component"/>
+        <rdfs:range rdf:resource="http://metacontrol.org/tomasys#FunctionDesign"/>
+    </owl:ObjectProperty>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -23,8 +86,8 @@
     //
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
-   
 
+    
 
     <!-- http://models21#f1_v1_r1 -->
 
@@ -57,6 +120,18 @@
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f1_v1_r3"/>
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f1_v1_r3"/>
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f1_v1_r3"/>
+        <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#f1_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#f1_v1_r3_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#FunctionDesign"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f1_v1_r3_k"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f1_v1_r3_k"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f1_v1_r3_k"/>
         <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
     </owl:NamedIndividual>
     
@@ -105,6 +180,18 @@
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f1_v3_r1"/>
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f1_v3_r1"/>
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f1_v3_r1"/>
+        <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#f1_v3_r1_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#f1_v3_r1_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#FunctionDesign"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f1_v3_r1_k"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f1_v3_r1_k"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f1_v3_r1_k"/>
         <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
     </owl:NamedIndividual>
     
@@ -165,6 +252,18 @@
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f2_v1_r3"/>
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f2_v1_r3"/>
         <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f2_v1_r3"/>
+        <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#f2_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#f2_v1_r3_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#FunctionDesign"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f2_v1_r3_k"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f2_v1_r3_k"/>
+        <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f2_v1_r3_k"/>
         <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
     </owl:NamedIndividual>
     
@@ -349,38 +448,6 @@
     </owl:NamedIndividual>
     
 
-    <!-- http://models21#f1_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#f1_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#FunctionDesign"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f1_v1_r3_k"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f1_v1_r3_k"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f1_v1_r3_k"/>
-        <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
-    </owl:NamedIndividual>
-
-
-    <!-- http://models21#f1_v3_r1_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#f1_v3_r1_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#FunctionDesign"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f1_v3_r1_k"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f1_v3_r1_k"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f1_v3_r1_k"/>
-        <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
-    </owl:NamedIndividual>
-    
-
-    <!-- http://models21#f2_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#f2_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#FunctionDesign"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_energy_f2_v1_r3_k"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_performance_f2_v1_r3_k"/>
-        <tomasys:hasQAestimation rdf:resource="http://models21#qa_safety_f2_v1_r3_k"/>
-        <tomasys:solvesF rdf:resource="http://ros/navigation_domain#f_navigate"/>
-    </owl:NamedIndividual>
-
 
     <!-- http://models21#qa_energy_f1_v1_r1 -->
 
@@ -405,6 +472,16 @@
     <!-- http://models21#qa_energy_f1_v1_r3 -->
 
     <owl:NamedIndividual rdf:about="http://models21#qa_energy_f1_v1_r3">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.33</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_energy_f1_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_energy_f1_v1_r3_k">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
         <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.33</tomasys:hasValue>
@@ -445,6 +522,16 @@
     <!-- http://models21#qa_energy_f1_v3_r1 -->
 
     <owl:NamedIndividual rdf:about="http://models21#qa_energy_f1_v3_r1">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.73</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_energy_f1_v3_r1_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_energy_f1_v3_r1_k">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
         <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.73</tomasys:hasValue>
@@ -495,6 +582,16 @@
     <!-- http://models21#qa_energy_f2_v1_r3 -->
 
     <owl:NamedIndividual rdf:about="http://models21#qa_energy_f2_v1_r3">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.38</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_energy_f2_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_energy_f2_v1_r3_k">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
         <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.38</tomasys:hasValue>
@@ -679,33 +776,6 @@
         <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
         <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1.5</tomasys:hasValue>
     </owl:NamedIndividual>
-
-
-        <!-- http://models21#qa_energy_f1_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_energy_f1_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.33</tomasys:hasValue>
-    </owl:NamedIndividual>
-
-
-        <!-- http://models21#qa_energy_f1_v3_r1_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_energy_f1_v3_r1_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.73</tomasys:hasValue>
-    </owl:NamedIndividual>
-
-
-        <!-- http://models21#qa_energy_f2_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_energy_f2_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#energy"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.38</tomasys:hasValue>
-    </owl:NamedIndividual>
     
 
 
@@ -734,7 +804,17 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_performance_f1_v1_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.0</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.1</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_performance_f1_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_performance_f1_v1_r3_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.01</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -775,6 +855,16 @@
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
         <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1.0</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_performance_f1_v3_r1_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_performance_f1_v3_r1_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.03</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -825,6 +915,16 @@
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
         <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.67</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_performance_f2_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_performance_f2_v1_r3_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.02</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -978,38 +1078,13 @@
     </owl:NamedIndividual>
     
 
-    <!-- http://models21#qa_performance_f1_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_performance_f1_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.00</tomasys:hasValue>
-    </owl:NamedIndividual>
-
-
-    <!-- http://models21#qa_performance_f1_v3_r1_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_performance_f1_v3_r1_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1.00</tomasys:hasValue>
-    </owl:NamedIndividual>
-
-
-    <!-- http://models21#qa_performance_f2_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_performance_f2_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#performance"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.67</tomasys:hasValue>
-    </owl:NamedIndividual>
 
     <!-- http://models21#qa_safety_f1_v1_r1 -->
 
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v1_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.68</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.32</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1019,7 +1094,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v1_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.7</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.3</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1029,7 +1104,17 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v1_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.71</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.29</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_safety_f1_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v1_r3_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.29</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1039,7 +1124,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v2_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.41</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.59</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1049,7 +1134,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v2_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.42</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.58</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1059,7 +1144,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v2_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.42</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.58</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1069,7 +1154,17 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v3_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.28</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.72</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_safety_f1_v3_r1_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v3_r1_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.72</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1079,7 +1174,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v3_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.27</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.73</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1089,7 +1184,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v3_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.26</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.74</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1099,7 +1194,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v1_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.66</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.34</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1109,7 +1204,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v1_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.69</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.31</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1119,7 +1214,17 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v1_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.71</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.29</tomasys:hasValue>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://models21#qa_safety_f2_v1_r3_k -->
+
+    <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v1_r3_k">
+        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
+        <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.29</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1129,7 +1234,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v2_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.41</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.59</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1139,7 +1244,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v2_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.42</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.58</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1149,7 +1254,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v2_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.43</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.57</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1159,7 +1264,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v3_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.28</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.72</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1169,7 +1274,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v3_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.28</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.72</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1179,7 +1284,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v3_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.28</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.72</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1189,7 +1294,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v1_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.62</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.38</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1199,7 +1304,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v1_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.7</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.3</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1209,7 +1314,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v1_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.69</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.31</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1219,7 +1324,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v2_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.42</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.58</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1229,7 +1334,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v2_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.41</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.59</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1239,7 +1344,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v2_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.42</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.58</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1249,7 +1354,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v3_r1">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.28</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.72</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1259,7 +1364,7 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v3_r2">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.28</tomasys:hasValue>
+        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.72</tomasys:hasValue>
     </owl:NamedIndividual>
     
 
@@ -1269,38 +1374,81 @@
     <owl:NamedIndividual rdf:about="http://models21#qa_safety_f3_v3_r3">
         <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
         <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.29</tomasys:hasValue>
-    </owl:NamedIndividual>
-
-
-
-    <!-- http://models21#qa_safety_f1_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
         <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.71</tomasys:hasValue>
     </owl:NamedIndividual>
+    
 
 
+    <!-- http://ros/navigation_domain#battery -->
 
-    <!-- http://models21#qa_safety_f1_v3_r1_k -->
+    <rdf:Description rdf:about="http://ros/navigation_domain#battery">
+        <mros:requiredBy rdf:resource="http://models21#f1_v1_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v1_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v2_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v2_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v2_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v3_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v3_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v3_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v1_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v1_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v1_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v2_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v2_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v2_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v3_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v3_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v3_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v1_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v1_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v1_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v2_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v2_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v2_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v3_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v3_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v3_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v3_r1_k"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v1_r3_k"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v1_r3_k"/>   
+    </rdf:Description>
+    
 
-    <owl:NamedIndividual rdf:about="http://models21#qa_safety_f1_v3_r1_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.28</tomasys:hasValue>
-    </owl:NamedIndividual>
 
+    <!-- http://ros/navigation_domain#laser_resender -->
 
-
-    <!-- http://models21#qa_safety_f2_v1_r3_k -->
-
-    <owl:NamedIndividual rdf:about="http://models21#qa_safety_f2_v1_r3_k">
-        <rdf:type rdf:resource="http://metacontrol.org/tomasys#QAvalue"/>
-        <tomasys:isQAtype rdf:resource="http://ros/mros#safety"/>
-        <tomasys:hasValue rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0.71</tomasys:hasValue>
-    </owl:NamedIndividual>
-
+    <rdf:Description rdf:about="http://ros/navigation_domain#laser_resender">
+        <mros:requiredBy rdf:resource="http://models21#f1_v1_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v1_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v1_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v2_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v2_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v2_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v3_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v3_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f1_v3_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v1_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v1_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v1_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v2_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v2_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v2_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v3_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v3_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f2_v3_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v1_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v1_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v1_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v2_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v2_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v2_r3"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v3_r1"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v3_r2"/>
+        <mros:requiredBy rdf:resource="http://models21#f3_v3_r3"/>
+    </rdf:Description>
 </rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
`safety` QA is corrected in all the `fd(s)` 

`laser_resender` and `battery` components are added as requirements for the corresponding `fd` (all but the fx_vx_rx_k)

This allows the reconfiguration by component failure to be triggered.